### PR TITLE
add Filipino language

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -22,6 +22,7 @@
     "eu": "Euskara",
     "fa": "فارس",
     "fi": "Suomi",
+    "fil": "Filipino",
     "fo": "Føroyskt",
     "fr": "Français",
     "ga": "Gaeilge",


### PR DESCRIPTION
There is fil_PH on Transifex, as Filipino seems to spoken on the Philipiens only, the _PH is superfluos, so that should get change to just fil.

https://github.com/musescore/MuseScore/pull/4576